### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 A Model Context Protocol server
 
+<a href="https://glama.ai/mcp/servers/xhqtor5rub">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/xhqtor5rub/badge" alt="Drupal-Modules-Server MCP server" />
+</a>
+
 This is a TypeScript-based MCP server that implements a simple notes system. It demonstrates core MCP concepts by providing:
 
 - Resources representing text notes with URIs and metadata


### PR DESCRIPTION
This PR adds a badge for the [Drupal-Modules-MCP MCP Server](https://glama.ai/mcp/servers/xhqtor5rub) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/xhqtor5rub">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/xhqtor5rub/badge" alt="Drupal-Modules-Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly asses that the MCP server is safe, server capabilities, and instructions for installing the server.